### PR TITLE
Add Deprecated field support for Bjoern scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An IntelliJ IDEA plugin for [Bjoern](https://github.com/Mehtrick/bjoern) BDD spe
   - `Version:`
   - `Reference:`
   - `Changelog:`
+  - `Deprecated:`
   - `Background:`
   - `Given:`
   - `When:`
@@ -18,6 +19,7 @@ An IntelliJ IDEA plugin for [Bjoern](https://github.com/Mehtrick/bjoern) BDD spe
   - `Scenarios:`
 - **Keyword Validation**: Only valid BDD keywords are highlighted; others are marked as invalid
 - **Reference Inspection**: Warns when the `Reference:` field contains an invalid URL scheme (only `http://` and `https://` are allowed) or a malformed markdown link `[text](url)`
+- **Deprecated Field Support**: Highlights `Deprecated:` inside scenarios, offers `true`/`false` completion, and validates placement and value via structural inspection
 - **Variable Highlighting**: Double-quoted strings are highlighted as variables with vibrant colors (e.g., `"john.doe"`, `"123"`)
 - **Comment Support**: Hash comments are properly highlighted with standard comment colors:
   - Full-line comments: `#This is a comment`
@@ -45,6 +47,7 @@ Background:
     - Initial setup step
 Scenarios:
   - Scenario: Test case name
+    Deprecated: false
     Given:
       - A user with username "john.doe"
       - Password is "securePassword123"
@@ -52,6 +55,14 @@ Scenarios:
       - User logs in with "john.doe"
     Then:
       - Login should display "Welcome!"
+  - Scenario: Legacy login flow
+    Deprecated: true
+    Given:
+      - A user with username "legacy.user"
+    When:
+      - User logs in with old API
+    Then:
+      - A deprecation warning is shown
 ```
 
 Variables in double quotes like `"john.doe"` and `"securePassword123"` are highlighted differently to distinguish them from regular text.
@@ -130,6 +141,7 @@ Create `.zgr` files and verify that:
 6. Auto-indentation works correctly
 7. Smart autocomplete provides relevant suggestions
 8. YAML structure is validated
+9. `Deprecated:` is only accepted inside scenarios with values `true` or `false`
 
 ## Requirements
 

--- a/src/main/java/de/mehtrick/bjoern/BjoernBreadcrumbsProvider.java
+++ b/src/main/java/de/mehtrick/bjoern/BjoernBreadcrumbsProvider.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.yaml.YAMLLanguage;
 import org.jetbrains.yaml.psi.YAMLKeyValue;
+import org.jetbrains.yaml.psi.YAMLMapping;
 import org.jetbrains.yaml.psi.YAMLScalar;
 import org.jetbrains.yaml.psi.YAMLSequenceItem;
 
@@ -69,7 +70,11 @@ public class BjoernBreadcrumbsProvider implements BreadcrumbsProvider {
                 if (value instanceof YAMLScalar) {
                     String textValue = ((YAMLScalar) value).getTextValue().trim();
                     if (!textValue.isEmpty()) {
-                        return key + ": " + textValue;
+                        String label = key + ": " + textValue;
+                        if ("Scenario".equals(key) && isDeprecatedScenario(kv)) {
+                            label += " (deprecated)";
+                        }
+                        return label;
                     }
                 }
             }
@@ -100,5 +105,17 @@ public class BjoernBreadcrumbsProvider implements BreadcrumbsProvider {
     @Override
     public String getElementTooltip(@NotNull PsiElement e) {
         return getElementInfo(e);
+    }
+
+    private static boolean isDeprecatedScenario(YAMLKeyValue scenarioKV) {
+        PsiElement parent = scenarioKV.getParent();
+        if (!(parent instanceof YAMLMapping scenarioMapping)) {
+            return false;
+        }
+        YAMLKeyValue deprecatedKV = scenarioMapping.getKeyValueByKey("Deprecated");
+        if (deprecatedKV == null) {
+            return false;
+        }
+        return "true".equals(deprecatedKV.getValueText().trim());
     }
 }

--- a/src/main/java/de/mehtrick/bjoern/BjoernColorSettingsPage.java
+++ b/src/main/java/de/mehtrick/bjoern/BjoernColorSettingsPage.java
@@ -61,12 +61,21 @@ public class BjoernColorSettingsPage implements ColorSettingsPage {
                     - A running system
                 Scenarios:
                   - Scenario: Happy path
+                    Deprecated: false
                     Given:
                       - A user with username "alice"
                     When:
                       - User logs in with password "secret"
                     Then:
                       - Dashboard is shown
+                  - Scenario: Legacy flow
+                    Deprecated: true
+                    Given:
+                      - An old feature flag
+                    When:
+                      - The flag is toggled
+                    Then:
+                      - A warning is shown
                 """;
     }
 

--- a/src/main/java/de/mehtrick/bjoern/BjoernCompletionContributor.java
+++ b/src/main/java/de/mehtrick/bjoern/BjoernCompletionContributor.java
@@ -24,8 +24,11 @@ import java.util.regex.Pattern;
 public class BjoernCompletionContributor extends CompletionContributor {
     private static final List<String> BDD_KEYWORDS = List.of(
             "Feature:", "Version:", "Reference:", "Changelog:",
-            "Background:", "Given:", "When:", "Then:", "Scenario:", "Scenarios:"
+            "Background:", "Given:", "When:", "Then:", "Scenario:", "Scenarios:",
+            "Deprecated:"
     );
+
+    private static final List<String> BOOLEAN_VALUES = List.of("true", "false");
     
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("\"[^\"]*\"");
 
@@ -74,7 +77,16 @@ public class BjoernCompletionContributor extends CompletionContributor {
                             .withTypeText("BDD Keyword"));
                 }
             }
-            
+
+            // Provide boolean completion for Deprecated: values
+            if (isDeprecatedValueContext(element)) {
+                for (String value : BOOLEAN_VALUES) {
+                    result.addElement(LookupElementBuilder.create(value)
+                            .withBoldness(true)
+                            .withTypeText("boolean"));
+                }
+            }
+
             // Provide smart completion based on context
             if (currentContext != null) {
                 Set<String> suggestions = extractStatementsFromFile(file, currentContext);
@@ -165,6 +177,28 @@ public class BjoernCompletionContributor extends CompletionContributor {
         }
         
         return null;
+    }
+
+    private static boolean isDeprecatedValueContext(PsiElement element) {
+        YAMLKeyValue currentKeyValue = PsiTreeUtil.getParentOfType(element, YAMLKeyValue.class);
+        if (currentKeyValue == null || !"Deprecated".equals(currentKeyValue.getKeyText())) {
+            return false;
+        }
+
+        // Ensure the caret is inside the Deprecated value, not inside the key itself.
+        YAMLValue value = currentKeyValue.getValue();
+        if (value == null) {
+            return false;
+        }
+
+        PsiElement current = element;
+        while (current != null && current != currentKeyValue) {
+            if (current == value) {
+                return true;
+            }
+            current = current.getParent();
+        }
+        return false;
     }
     
     private static Set<String> extractStatementsFromFile(PsiFile file, String contextType) {

--- a/src/main/java/de/mehtrick/bjoern/BjoernKeywordValidationLexer.java
+++ b/src/main/java/de/mehtrick/bjoern/BjoernKeywordValidationLexer.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class BjoernKeywordValidationLexer extends LexerBase {
     private static final Set<String> VALID_BDD_KEYWORDS = Set.of(
             "Feature", "Background", "Given", "When", "Then", "Scenario", "Scenarios",
-            "Version", "Reference", "Changelog"
+            "Version", "Reference", "Changelog", "Deprecated"
     );
     
     private CharSequence buffer;

--- a/src/main/java/de/mehtrick/bjoern/BjoernStructureInspection.java
+++ b/src/main/java/de/mehtrick/bjoern/BjoernStructureInspection.java
@@ -2,6 +2,7 @@ package de.mehtrick.bjoern;
 
 import com.intellij.codeInspection.*;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.*;
@@ -16,12 +17,15 @@ import java.util.*;
  *   <li>Required top-level fields {@code Feature:} and {@code Scenarios:} must be present.</li>
  *   <li>Duplicate scenario names within the same file are flagged as warnings.</li>
  *   <li>Empty {@code Given:}, {@code When:} or {@code Then:} blocks (no list items) are warned about.</li>
+ *   <li>{@code Deprecated:} is only allowed inside a scenario and must have the value {@code true} or {@code false}.</li>
  * </ol>
  */
 public class BjoernStructureInspection extends LocalInspectionTool {
 
     private static final Set<String> REQUIRED_TOP_LEVEL = Set.of("Feature", "Scenarios");
     private static final Set<String> BDD_STEP_KEYS = Set.of("Given", "When", "Then");
+    static final String DEPRECATED_KEY = "Deprecated";
+    private static final Set<String> VALID_DEPRECATED_VALUES = Set.of("true", "false");
 
     @Override
     public ProblemDescriptor @NotNull [] checkFile(@NotNull PsiFile file,
@@ -45,6 +49,7 @@ public class BjoernStructureInspection extends LocalInspectionTool {
             checkRequiredTopLevelFields(mapping, manager, isOnTheFly, problems, file);
             checkDuplicateScenarioNames(mapping, manager, isOnTheFly, problems);
             checkEmptyStepBlocks(mapping, manager, isOnTheFly, problems);
+            checkDeprecatedFields(mapping, manager, isOnTheFly, problems);
         }
 
         return problems.toArray(ProblemDescriptor.EMPTY_ARRAY);
@@ -182,6 +187,95 @@ public class BjoernStructureInspection extends LocalInspectionTool {
                     LocalQuickFix.EMPTY_ARRAY,
                     ProblemHighlightType.WEAK_WARNING));
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Check 4: Deprecated field placement and value
+    // -------------------------------------------------------------------------
+    private void checkDeprecatedFields(YAMLMapping mapping,
+                                       InspectionManager manager,
+                                       boolean isOnTheFly,
+                                       List<ProblemDescriptor> problems) {
+        collectDeprecatedKeyValues(mapping, manager, isOnTheFly, problems);
+    }
+
+    private void collectDeprecatedKeyValues(YAMLValue value,
+                                            InspectionManager manager,
+                                            boolean isOnTheFly,
+                                            List<ProblemDescriptor> problems) {
+        if (value instanceof YAMLMapping mapping) {
+            for (YAMLKeyValue kv : mapping.getKeyValues()) {
+                if (DEPRECATED_KEY.equals(kv.getKeyText())) {
+                    validateDeprecatedKeyValue(kv, manager, isOnTheFly, problems);
+                }
+                YAMLValue childValue = kv.getValue();
+                if (childValue instanceof YAMLMapping || childValue instanceof YAMLSequence) {
+                    collectDeprecatedKeyValues(childValue, manager, isOnTheFly, problems);
+                }
+            }
+        } else if (value instanceof YAMLSequence sequence) {
+            for (YAMLSequenceItem item : sequence.getItems()) {
+                collectDeprecatedKeyValues(item.getValue(), manager, isOnTheFly, problems);
+            }
+        }
+    }
+
+    private void validateDeprecatedKeyValue(YAMLKeyValue deprecatedKV,
+                                            InspectionManager manager,
+                                            boolean isOnTheFly,
+                                            List<ProblemDescriptor> problems) {
+        if (!isInsideScenario(deprecatedKV)) {
+            problems.add(manager.createProblemDescriptor(
+                    deprecatedKV,
+                    "'Deprecated:' is only allowed inside a scenario",
+                    isOnTheFly,
+                    LocalQuickFix.EMPTY_ARRAY,
+                    ProblemHighlightType.WARNING));
+        }
+
+        String valueText = deprecatedKV.getValueText().trim();
+        if (!VALID_DEPRECATED_VALUES.contains(valueText)) {
+            problems.add(manager.createProblemDescriptor(
+                    deprecatedKV,
+                    "'Deprecated:' value must be 'true' or 'false' but found '" + valueText + "'",
+                    isOnTheFly,
+                    LocalQuickFix.EMPTY_ARRAY,
+                    ProblemHighlightType.WARNING));
+        }
+    }
+
+    private boolean isInsideScenario(YAMLKeyValue deprecatedKV) {
+        // Deprecated: must be a direct key of a scenario mapping.
+        PsiElement parent = deprecatedKV.getParent();
+        if (!(parent instanceof YAMLMapping)) {
+            return false;
+        }
+
+        PsiElement scenarioKV = parent.getParent();
+        if (!(scenarioKV instanceof YAMLKeyValue) || !"Scenario".equals(((YAMLKeyValue) scenarioKV).getKeyText())) {
+            return false;
+        }
+
+        PsiElement sequenceItem = scenarioKV.getParent();
+        if (!(sequenceItem instanceof YAMLSequenceItem)) {
+            return false;
+        }
+
+        PsiElement sequence = sequenceItem.getParent();
+        if (!(sequence instanceof YAMLSequence)) {
+            return false;
+        }
+
+        PsiElement scenariosKV = sequence.getParent();
+        return scenariosKV instanceof YAMLKeyValue && "Scenarios".equals(((YAMLKeyValue) scenariosKV).getKeyText());
+    }
+
+    /**
+     * Returns {@code true} when the supplied value is a valid Deprecated field value
+     * ({@code true} or {@code false}). Used by tests and can be reused by other callers.
+     */
+    static boolean isValidDeprecatedValue(String value) {
+        return value != null && VALID_DEPRECATED_VALUES.contains(value.trim());
     }
 }
 

--- a/src/main/resources/fileTemplates/internal/Bjoern Spec.zgr.ft
+++ b/src/main/resources/fileTemplates/internal/Bjoern Spec.zgr.ft
@@ -7,6 +7,7 @@ Background:
     -
 Scenarios:
   - Scenario: First scenario
+    Deprecated: false
     Given:
       -
     When:

--- a/src/test/java/de/mehtrick/bjoern/BjoernCompletionTest.java
+++ b/src/test/java/de/mehtrick/bjoern/BjoernCompletionTest.java
@@ -1,6 +1,8 @@
 package de.mehtrick.bjoern;
 
 
+import java.lang.reflect.Field;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class BjoernCompletionTest {
@@ -134,6 +136,28 @@ public class BjoernCompletionTest {
         int[] afterFoo = BjoernTabHandler.findNextParameter(filled, insideFoo);
         if (afterFoo == null || afterFoo[0] != filled.indexOf("\"\"")) {
             throw new AssertionError("Tab from filled parameter should navigate to next parameter");
+        }
+    }
+
+    public void testDeprecatedKeywordIsOffered() throws Exception {
+        Field keywordsField = BjoernCompletionContributor.class.getDeclaredField("BDD_KEYWORDS");
+        keywordsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<String> keywords = (List<String>) keywordsField.get(null);
+
+        if (!keywords.contains("Deprecated:")) {
+            throw new AssertionError("BDD keyword completion should include 'Deprecated:'");
+        }
+    }
+
+    public void testBooleanValuesForDeprecated() throws Exception {
+        Field booleanField = BjoernCompletionContributor.class.getDeclaredField("BOOLEAN_VALUES");
+        booleanField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<String> values = (List<String>) booleanField.get(null);
+
+        if (!values.contains("true") || !values.contains("false")) {
+            throw new AssertionError("Deprecated value completion should include 'true' and 'false'");
         }
     }
 }

--- a/src/test/java/de/mehtrick/bjoern/BjoernKeywordValidationLexerTest.java
+++ b/src/test/java/de/mehtrick/bjoern/BjoernKeywordValidationLexerTest.java
@@ -1,0 +1,36 @@
+package de.mehtrick.bjoern;
+
+import com.intellij.psi.tree.IElementType;
+
+public class BjoernKeywordValidationLexerTest {
+
+    public void testDeprecatedIsValidKeyword() {
+        BjoernKeywordValidationLexer lexer = new BjoernKeywordValidationLexer();
+        lexer.start("Deprecated:", 0, 11, 0);
+
+        IElementType tokenType = lexer.getTokenType();
+        if (tokenType != BjoernTokenTypes.VALID_KEYWORD) {
+            throw new AssertionError("Expected Deprecated: to be a valid BDD keyword, but got " + tokenType);
+        }
+    }
+
+    public void testDeprecatedWithoutColonIsValidKeyword() {
+        BjoernKeywordValidationLexer lexer = new BjoernKeywordValidationLexer();
+        lexer.start("Deprecated", 0, 10, 0);
+
+        IElementType tokenType = lexer.getTokenType();
+        if (tokenType != BjoernTokenTypes.VALID_KEYWORD) {
+            throw new AssertionError("Expected Deprecated to be a valid BDD keyword, but got " + tokenType);
+        }
+    }
+
+    public void testUnknownKeywordIsInvalid() {
+        BjoernKeywordValidationLexer lexer = new BjoernKeywordValidationLexer();
+        lexer.start("Unknown:", 0, 8, 0);
+
+        IElementType tokenType = lexer.getTokenType();
+        if (tokenType != BjoernTokenTypes.INVALID_KEYWORD) {
+            throw new AssertionError("Expected Unknown: to be an invalid BDD keyword, but got " + tokenType);
+        }
+    }
+}

--- a/src/test/java/de/mehtrick/bjoern/BjoernStructureInspectionTest.java
+++ b/src/test/java/de/mehtrick/bjoern/BjoernStructureInspectionTest.java
@@ -1,0 +1,32 @@
+package de.mehtrick.bjoern;
+
+public class BjoernStructureInspectionTest {
+
+    public void testInspectionCanBeInstantiated() {
+        BjoernStructureInspection inspection = new BjoernStructureInspection();
+        if (inspection == null) {
+            throw new AssertionError("Structure inspection should not be null");
+        }
+    }
+
+    public void testValidDeprecatedValues() {
+        if (!BjoernStructureInspection.isValidDeprecatedValue("true")) {
+            throw new AssertionError("'true' should be a valid Deprecated value");
+        }
+        if (!BjoernStructureInspection.isValidDeprecatedValue("false")) {
+            throw new AssertionError("'false' should be a valid Deprecated value");
+        }
+    }
+
+    public void testInvalidDeprecatedValues() {
+        if (BjoernStructureInspection.isValidDeprecatedValue("yes")) {
+            throw new AssertionError("'yes' should not be a valid Deprecated value");
+        }
+        if (BjoernStructureInspection.isValidDeprecatedValue("1")) {
+            throw new AssertionError("'1' should not be a valid Deprecated value");
+        }
+        if (BjoernStructureInspection.isValidDeprecatedValue("")) {
+            throw new AssertionError("empty string should not be a valid Deprecated value");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds IntelliJ IDEA support for the `Deprecated:` field that was recently introduced in the Bjoern framework.

## Changes
- Recognize `Deprecated:` as a valid BDD keyword in the validation lexer
- Offer `Deprecated:` and boolean `true`/`false` values in code completion
- Validate placement (only inside scenarios) and value via structure inspection
- Show deprecated scenarios in breadcrumbs with `(deprecated)` suffix
- Include `Deprecated:` in the new-file template and color settings demo
- Add tests for keyword validation, completion, and deprecated value validation
- Update README with `Deprecated:` field documentation

## Motivation
The Bjoern framework now supports marking individual scenarios as deprecated (see bjoern framework PR #104). The IntelliJ plugin should recognize and assist with this field to keep editor support in sync with the framework.

## Testing
- `./gradlew build` passes
- New unit tests cover lexer validation and completion constants